### PR TITLE
null-safety for setting parents

### DIFF
--- a/spring-social-google/spring-social-google/src/main/java/org/springframework/social/google/api/drive/DriveFile.java
+++ b/spring-social-google/spring-social-google/src/main/java/org/springframework/social/google/api/drive/DriveFile.java
@@ -130,7 +130,9 @@ public class DriveFile extends ApiEntity {
 			file.modifiedDate = modifiedDate;
 			file.parents = new ArrayList<DriveFileParent>();
 			for(String parentId : parentIds) {
-				file.parents.add(new DriveFileParent(parentId));
+				if(parentId != null){
+					file.parents.add(new DriveFileParent(parentId));
+				}
 			}
 			return file;
 		}


### PR DESCRIPTION
add parents only if parentId is not null, which will result in the file being in the root collection ('My Drive')
