### PR TITLE
Publish artifact to Sonatype OSS so it can be synced to Maven Central

### DIFF
--- a/spring-social-google/spring-social-google/pom.xml
+++ b/spring-social-google/spring-social-google/pom.xml
@@ -1,10 +1,21 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.springframework.social</groupId>
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>7</version>
+    </parent>
+    <groupId>com.gabiaxel</groupId>
 	<artifactId>spring-social-google</artifactId>
 	<name>Spring Social Google</name>
 	<version>1.0.0.BUILD-SNAPSHOT</version>
+
+    <scm>
+        <url>scm:git:git@github.com:GabiAxel/spring-social-google.git</url>
+        <connection>scm:git:git@github.com:GabiAxel/spring-social-google.git</connection>
+        <developerConnection>scm:git:git@github.com:GabiAxel/spring-social-google.git</developerConnection>
+    </scm>
 
 	<properties>
 		<spring.social.version>1.1.0.BUILD-SNAPSHOT</spring.social.version>


### PR DESCRIPTION
This should resolve https://github.com/GabiAxel/spring-social-google/issues/5

Note there are further steps required here: https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide

Also, in compliance with Sonatype OSS practices I changed the groupId to com.gabiaxel.

I hope this is helpful in increasing the accessibility of this artifact as well as Spring Social!
