### PR TITLE
getPeopleInCircles method doesn't pass pageToken to google+ service

### DIFF
--- a/spring-social-google/src/main/java/org/springframework/social/google/api/plus/impl/PlusTemplate.java
+++ b/spring-social-google/src/main/java/org/springframework/social/google/api/plus/impl/PlusTemplate.java
@@ -117,7 +117,11 @@ public class PlusTemplate extends AbstractGoogleApiOperations implements PlusOpe
 
 	@Override
 	public PeoplePage getPeopleInCircles(String id, String pageToken) {
-		return getEntity(PEOPLE_URL + id + "/people/visible", PeoplePage.class);
+		StringBuilder sb = new StringBuilder(PEOPLE_URL + id + "/people/visible");
+		if(hasText(pageToken)) {
+			sb.append("?pageToken=").append(pageToken);
+		}
+		return getEntity(sb.toString(), PeoplePage.class);
 	}
 	
 	@Override


### PR DESCRIPTION
Google+ always returns 100 rows (person) per one api call, to acquire
anything more than 100 rows, pagetoken should be passed to Google+
service
