### PR TITLE
Add people api

### DIFF
--- a/src/main/java/org/springframework/social/google/api/Google.java
+++ b/src/main/java/org/springframework/social/google/api/Google.java
@@ -20,6 +20,7 @@ import org.springframework.social.google.api.calendar.CalendarOperations;
 import org.springframework.social.google.api.drive.DriveOperations;
 import org.springframework.social.google.api.impl.GoogleTemplate;
 import org.springframework.social.google.api.oauth2.OAuth2Operations;
+import org.springframework.social.google.api.people.PeopleOperations;
 import org.springframework.social.google.api.plus.PlusOperations;
 import org.springframework.social.google.api.tasks.TaskOperations;
 import org.springframework.web.client.RestOperations;
@@ -87,6 +88,14 @@ public interface Google extends ApiBinding {
    * @return {@link CalendarOperations} for the authenticated user if authenticated
    */
   CalendarOperations calendarOperations();
+
+  /**
+   * Retrieves {@link PeopleOperations}, used for interacting with Google People API.
+   * Some methods require OAuth2 scope https://people.googleapis.com/v1/me
+   *
+   * @return {@link PeopleOperations} for the authenticated user if authenticated
+   */
+  PeopleOperations peopleOperations();
 
   /**
    * Returns the access token, allowing interoperability with other libraries

--- a/src/main/java/org/springframework/social/google/api/impl/GoogleTemplate.java
+++ b/src/main/java/org/springframework/social/google/api/impl/GoogleTemplate.java
@@ -36,6 +36,8 @@ import org.springframework.social.google.api.drive.DriveOperations;
 import org.springframework.social.google.api.drive.impl.DriveTemplate;
 import org.springframework.social.google.api.oauth2.OAuth2Operations;
 import org.springframework.social.google.api.oauth2.impl.OAuth2Template;
+import org.springframework.social.google.api.people.PeopleOperations;
+import org.springframework.social.google.api.people.impl.PeopleTemplate;
 import org.springframework.social.google.api.plus.PlusOperations;
 import org.springframework.social.google.api.plus.impl.PlusTemplate;
 import org.springframework.social.google.api.tasks.TaskOperations;
@@ -65,6 +67,7 @@ public class GoogleTemplate extends AbstractOAuth2ApiBinding implements Google {
   private TaskOperations taskOperations;
   private DriveOperations driveOperations;
   private CalendarOperations calendarOperations;
+  private PeopleOperations peopleOperations;
 
   /**
    * Creates a new instance of GoogleTemplate.
@@ -91,6 +94,7 @@ public class GoogleTemplate extends AbstractOAuth2ApiBinding implements Google {
     taskOperations = new TaskTemplate(getRestTemplate(), isAuthorized());
     driveOperations = new DriveTemplate(getRestTemplate(), isAuthorized());
     calendarOperations = new CalendarTemplate(getRestTemplate(), isAuthorized());
+    peopleOperations = new PeopleTemplate(getRestTemplate(), isAuthorized());
   }
 
   @Override
@@ -138,6 +142,11 @@ public class GoogleTemplate extends AbstractOAuth2ApiBinding implements Google {
   @Override
   public CalendarOperations calendarOperations() {
     return calendarOperations;
+  }
+
+  @Override
+  public PeopleOperations peopleOperations() {
+    return peopleOperations;
   }
 
   @Override

--- a/src/main/java/org/springframework/social/google/api/people/Birthday.java
+++ b/src/main/java/org/springframework/social/google/api/people/Birthday.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.people;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+
+/**
+ * Model class representing a birthday in google people
+ * @author Oscar Carballo
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Birthday {
+
+  private Date date;
+
+  public Date getDate() {
+    return date;
+  }
+}

--- a/src/main/java/org/springframework/social/google/api/people/Date.java
+++ b/src/main/java/org/springframework/social/google/api/people/Date.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.people;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Model class representing a date in google people
+ * @author Oscar Carballo
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Date {
+
+  private Integer year;
+
+  private Integer month;
+
+  private Integer day;
+
+  public Integer getYear() {
+    return year;
+  }
+
+  public Integer getMonth() {
+    return month;
+  }
+
+  public Integer getDay() {
+    return day;
+  }
+}

--- a/src/main/java/org/springframework/social/google/api/people/EmailAddress.java
+++ b/src/main/java/org/springframework/social/google/api/people/EmailAddress.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.people;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Model class representing an email address in google people
+ * @author Oscar Carballo
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EmailAddress {
+
+  private String value;
+
+
+  public String getValue() {
+    return value;
+  }
+}

--- a/src/main/java/org/springframework/social/google/api/people/Gender.java
+++ b/src/main/java/org/springframework/social/google/api/people/Gender.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.people;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Model class representing a gender in google people
+ * @author Oscar Carballo
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Gender {
+
+  public String getValue() {
+    return value;
+  }
+
+  private String value;
+
+}

--- a/src/main/java/org/springframework/social/google/api/people/Name.java
+++ b/src/main/java/org/springframework/social/google/api/people/Name.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.people;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+
+/**
+ * Model class representing a name in google people
+ * @author Oscar Carballo
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Name {
+
+  private String familyName;
+
+  private String givenName;
+
+  public String getFamilyName() {
+    return familyName;
+  }
+
+  public String getGivenName() {
+    return givenName;
+  }
+}

--- a/src/main/java/org/springframework/social/google/api/people/PeopleOperations.java
+++ b/src/main/java/org/springframework/social/google/api/people/PeopleOperations.java
@@ -15,23 +15,69 @@
  */
 package org.springframework.social.google.api.people;
 
-
+/**
+ * Defines operations for searching and retrieving Google people information. To use "me" as user ID,
+ * requires OAuth2 authentication.
+ *
+ *
+ * @author Oscar Carballo
+ */
 public interface PeopleOperations {
 
   /**
-   * Retrieves a user's Google profile.
+   * All the fields available in google people api. In order to get a field value, the authentication
+   * must have been done with the right scope.
+   */
+  String ALL_FIELDS = "addresses,ageRanges,biographies,birthdays,braggingRights,coverPhotos,"
+    + "emailAddresses,events,genders,imClients,interests,locales,memberships,metadata,names,nicknames,occupations,"
+    + "organizations,phoneNumbers,photos,relations,relationshipInterests,relationshipStatuses,residences,skills"
+    + "taglines,urls";
+
+  /**
+   * Retrieves a user's Google profile. Google people api requires to send the fields you want back.
+   * This will try to retrieve all fields for that user. The expected values will be returned
+   * as long as the right scope has been requested previously
    *
    * @param id user ID or "me"
    * @return the retrieved {@link PeoplePerson}
    */
   PeoplePerson getPerson(final String id);
 
+  /**
+   * Retrieves a user's Google profile populated with the requested fields. Google people api
+   * requires to send the fields you want back. This will try to retrieve the fields passed in.
+   * The expected values will be returned as long as the right scope has been
+   * requested previously
+   *
+   * @param id user ID or "me"
+   * @param fields comma separated values containing the desired fields
+   * @return the retrieved {@link PeoplePerson}
+   */
+  PeoplePerson getPerson(final String id, String fields);
+
 
   /**
-   * Retrieves the authenticated user's Google profile.
+   * Retrieves the authenticated user's complete Google profile. Google people api requires to
+   * send the fields you want back.
+   * This will try to retrieve all fields for that user. The expected values will be
+   * returned as long as the right scope has been requested previously
    *
    * @return the retrieved {@link PeoplePerson}
    */
   PeoplePerson getGoogleProfile();
+
+
+  /**
+   * Retrieves the authenticated user's complete Google profile. Google people api requires to
+   * send the fields you want back.
+   * This will try to retrieve the fields passed in. The expected values will be
+   * returned as long as the right scope has been requested previously
+   *
+   * @param fields user ID or "me"
+   * @return the retrieved {@link PeoplePerson}
+   */
+  PeoplePerson getGoogleProfile(final String fields);
+
+
 
 }

--- a/src/main/java/org/springframework/social/google/api/people/PeopleOperations.java
+++ b/src/main/java/org/springframework/social/google/api/people/PeopleOperations.java
@@ -30,7 +30,7 @@ public interface PeopleOperations {
    */
   String ALL_FIELDS = "addresses,ageRanges,biographies,birthdays,braggingRights,coverPhotos,"
     + "emailAddresses,events,genders,imClients,interests,locales,memberships,metadata,names,nicknames,occupations,"
-    + "organizations,phoneNumbers,photos,relations,relationshipInterests,relationshipStatuses,residences,skills"
+    + "organizations,phoneNumbers,photos,relations,relationshipInterests,relationshipStatuses,residences,skills,"
     + "taglines,urls";
 
   /**

--- a/src/main/java/org/springframework/social/google/api/people/PeopleOperations.java
+++ b/src/main/java/org/springframework/social/google/api/people/PeopleOperations.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.people;
+
+
+public interface PeopleOperations {
+
+  /**
+   * Retrieves a user's Google profile.
+   *
+   * @param id user ID or "me"
+   * @return the retrieved {@link PeoplePerson}
+   */
+  PeoplePerson getPerson(final String id);
+
+
+  /**
+   * Retrieves the authenticated user's Google profile.
+   *
+   * @return the retrieved {@link PeoplePerson}
+   */
+  PeoplePerson getGoogleProfile();
+
+}

--- a/src/main/java/org/springframework/social/google/api/people/PeoplePerson.java
+++ b/src/main/java/org/springframework/social/google/api/people/PeoplePerson.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.people;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.springframework.social.google.api.ApiEntity;
+
+/**
+ * Model class representing a full Google profile in people
+ * @author Oscar Carballo
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PeoplePerson extends ApiEntity {
+
+  private List<Name> names;
+
+  private List<Gender> genders;
+
+  private List<Birthday> birthdays;
+
+  private List<EmailAddress> emailAddresses;
+
+  private PersonMetada metadata;
+
+  private List<Photo> photos;
+
+  @Override
+  public String getId() {
+    return getMetadata().getSources().get(0).getId();
+  }
+
+  @Override
+  public String getEtag() {
+    return getMetadata().getSources().get(0).getEtag();
+  }
+
+
+  public List<Name> getNames() {
+    return names;
+  }
+
+  public List<Gender> getGenders() {
+    return genders;
+  }
+
+  public List<Birthday> getBirthdays() {
+    return birthdays;
+  }
+
+  public List<EmailAddress> getEmailAddresses() {
+    return emailAddresses;
+  }
+
+  public PersonMetada getMetadata() {
+    return metadata;
+  }
+
+  public List<Photo> getPhotos() {
+    return photos;
+  }
+}

--- a/src/main/java/org/springframework/social/google/api/people/PersonMetada.java
+++ b/src/main/java/org/springframework/social/google/api/people/PersonMetada.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.people;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Model class representing metadata in google people
+ * @author Oscar Carballo
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PersonMetada {
+
+  private List<Sources> sources;
+
+  public List<Sources> getSources() {
+    return sources;
+  }
+}

--- a/src/main/java/org/springframework/social/google/api/people/Photo.java
+++ b/src/main/java/org/springframework/social/google/api/people/Photo.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.people;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Model class representing a photo in google people
+ * @author Oscar Carballo
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Photo {
+
+  private String url;
+
+  public String getUrl() {
+    return url;
+  }
+}

--- a/src/main/java/org/springframework/social/google/api/people/Sources.java
+++ b/src/main/java/org/springframework/social/google/api/people/Sources.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.people;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Model class representing sources metadata info in google people
+ * @author Oscar Carballo
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Sources {
+
+  private String id;
+
+  private String etag;
+
+  public String getId() {
+    return id;
+  }
+
+  public String getEtag() {
+    return etag;
+  }
+}

--- a/src/main/java/org/springframework/social/google/api/people/impl/PeopleTemplate.java
+++ b/src/main/java/org/springframework/social/google/api/people/impl/PeopleTemplate.java
@@ -19,6 +19,7 @@ import org.springframework.social.google.api.impl.AbstractGoogleApiOperations;
 import org.springframework.social.google.api.people.PeopleOperations;
 import org.springframework.social.google.api.people.PeoplePerson;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 
 /**
@@ -34,8 +35,13 @@ public class PeopleTemplate extends AbstractGoogleApiOperations implements Peopl
   }
 
   @Override
-  public PeoplePerson getPerson(final String id) {
-    return getEntity(PEOPLE_URL + id, PeoplePerson.class);
+  public PeoplePerson getPerson(String id) {
+    return getEntity(buildUrl(PEOPLE_URL + id, ALL_FIELDS), PeoplePerson.class);
+  }
+
+  @Override
+  public PeoplePerson getPerson(String id, String fields) {
+    return getEntity(buildUrl(PEOPLE_URL + id, fields), PeoplePerson.class);
   }
 
   @Override
@@ -43,5 +49,14 @@ public class PeopleTemplate extends AbstractGoogleApiOperations implements Peopl
     return getPerson("me");
   }
 
+  @Override
+  public PeoplePerson getGoogleProfile(String fields) {
+    return getPerson("me", fields);
+  }
 
+  private static String buildUrl(String url, String personFieldsValue) {
+    return UriComponentsBuilder.fromHttpUrl(url)
+      .queryParam("personFields", personFieldsValue)
+      .build().toString();
+  }
 }

--- a/src/main/java/org/springframework/social/google/api/people/impl/PeopleTemplate.java
+++ b/src/main/java/org/springframework/social/google/api/people/impl/PeopleTemplate.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.people.impl;
+
+import org.springframework.social.google.api.impl.AbstractGoogleApiOperations;
+import org.springframework.social.google.api.people.PeopleOperations;
+import org.springframework.social.google.api.people.PeoplePerson;
+import org.springframework.web.client.RestTemplate;
+
+
+/**
+ * {@link PeopleOperations} implementation.
+ * @author Oscar Carballo
+ */
+public class PeopleTemplate extends AbstractGoogleApiOperations implements PeopleOperations {
+
+  private static final String PEOPLE_URL = "https://people.googleapis.com/v1/people/";
+
+  public PeopleTemplate(final RestTemplate restTemplate, final boolean isAuthorized) {
+    super(restTemplate, isAuthorized);
+  }
+
+  @Override
+  public PeoplePerson getPerson(final String id) {
+    return getEntity(PEOPLE_URL + id, PeoplePerson.class);
+  }
+
+  @Override
+  public PeoplePerson getGoogleProfile() {
+    return getPerson("me");
+  }
+
+
+}

--- a/src/test/java/org/springframework/social/google/api/people/PeopleTemplateTest.java
+++ b/src/test/java/org/springframework/social/google/api/people/PeopleTemplateTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.social.google.api.people.impl.PeopleTemplate.ALL_FIELDS;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
@@ -31,9 +32,10 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 public class PeopleTemplateTest extends AbstractGoogleApiTest {
 
   @Test
-  public void getPersonById() {
+  public void getFullPersonById() {
     mockServer
-      .expect(requestTo("https://people.googleapis.com/v1/people/115661085724677333632?access_token=ACCESS_TOKEN"))
+      .expect(requestTo("https://people.googleapis.com/v1/people/115661085724677333632?personFields=" +
+        ALL_FIELDS + "&access_token=ACCESS_TOKEN"))
       .andExpect(method(GET))
       .andRespond(
         withSuccess(jsonResource("people"), APPLICATION_JSON));
@@ -42,14 +44,40 @@ public class PeopleTemplateTest extends AbstractGoogleApiTest {
   }
 
   @Test
-  public void getSelfProfile() {
+  public void getFullSelfProfile() {
     mockServer
-      .expect(requestTo("https://people.googleapis.com/v1/people/me?access_token=ACCESS_TOKEN"))
+      .expect(requestTo("https://people.googleapis.com/v1/people/me?personFields="
+        + ALL_FIELDS + "&access_token=ACCESS_TOKEN"))
       .andExpect(method(GET))
       .andRespond(
         withSuccess(jsonResource("people"), APPLICATION_JSON));
     final PeoplePerson person = google.peopleOperations().getGoogleProfile();
     assertPerson(person);
+  }
+
+  @Test
+  public void getPersonByIdAndFields() {
+    mockServer
+      .expect(requestTo("https://people.googleapis.com/v1/people/115661085724677333632?" +
+        "personFields=names,genders&access_token=ACCESS_TOKEN"))
+      .andExpect(method(GET))
+      .andRespond(
+        withSuccess(jsonResource("people"), APPLICATION_JSON));
+    final PeoplePerson person = google.peopleOperations().getPerson("115661085724677333632", "names,genders");
+    assertPerson(person); // In a real api call only names and genders would be there.
+  }
+
+
+  @Test
+  public void getSelfProfileWithFields() {
+    mockServer
+      .expect(requestTo("https://people.googleapis.com/v1/people/me?" +
+        "personFields=names,genders&access_token=ACCESS_TOKEN"))
+      .andExpect(method(GET))
+      .andRespond(
+        withSuccess(jsonResource("people"), APPLICATION_JSON));
+    final PeoplePerson person = google.peopleOperations().getGoogleProfile("names,genders");
+    assertPerson(person); // In a real api call only names and genders would be there.
   }
 
   private void assertPerson(final PeoplePerson person) {

--- a/src/test/java/org/springframework/social/google/api/people/PeopleTemplateTest.java
+++ b/src/test/java/org/springframework/social/google/api/people/PeopleTemplateTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.google.api.people;
+
+import org.junit.Test;
+import org.springframework.social.google.api.AbstractGoogleApiTest;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+public class PeopleTemplateTest extends AbstractGoogleApiTest {
+
+  @Test
+  public void getPersonById() {
+    mockServer
+      .expect(requestTo("https://people.googleapis.com/v1/people/115661085724677333632?access_token=ACCESS_TOKEN"))
+      .andExpect(method(GET))
+      .andRespond(
+        withSuccess(jsonResource("people"), APPLICATION_JSON));
+    final PeoplePerson person = google.peopleOperations().getPerson("115661085724677333632");
+    assertPerson(person);
+  }
+
+  @Test
+  public void getSelfProfile() {
+    mockServer
+      .expect(requestTo("https://people.googleapis.com/v1/people/me?access_token=ACCESS_TOKEN"))
+      .andExpect(method(GET))
+      .andRespond(
+        withSuccess(jsonResource("people"), APPLICATION_JSON));
+    final PeoplePerson person = google.peopleOperations().getGoogleProfile();
+    assertPerson(person);
+  }
+
+  private void assertPerson(final PeoplePerson person) {
+    assertNotNull(person);
+    assertEquals("115661085724677333632", person.getMetadata().getSources().get(0).getId());
+    assertEquals("115661085724677333632", person.getId());
+    assertEquals("#8OZqg2xl60w=", person.getMetadata().getSources().get(0).getEtag());
+    assertEquals("#8OZqg2xl60w=", person.getEtag());
+    assertThat(person.getNames().get(0).getGivenName(), is("Oscar"));
+    assertThat(person.getNames().get(0).getFamilyName(), is("Carballo"));
+    assertThat(person.getBirthdays().get(0).getDate().getDay(), is(21));
+    assertThat(person.getBirthdays().get(0).getDate().getMonth(), is(10));
+    assertThat(person.getBirthdays().get(0).getDate().getYear(), is(1979));
+    assertThat(person.getGenders().get(0).getValue(), is("male"));
+    assertThat(person.getEmailAddresses().get(0).getValue(), is("oscar.carballo@scout24.com"));
+    assertThat(person.getPhotos().get(0).getUrl(), is("https://lh6.googleusercontent.com/-1lUywZzxLoQ/AAAAAAAAAAI/AAAAAAAAAC0/c95Whdc5AAA/s100/photo.jpg"));
+  }
+
+}

--- a/src/test/resources/org/springframework/social/google/api/people/people.json
+++ b/src/test/resources/org/springframework/social/google/api/people/people.json
@@ -1,0 +1,113 @@
+{
+  "resourceName": "people/115661085724677333632",
+  "etag": "%EgcBBwgCAwku",
+  "metadata": {
+    "sources": [
+      {
+        "type": "PROFILE",
+        "id": "115661085724677333632",
+        "etag": "#8OZqg2xl60w=",
+        "profileMetadata": {
+          "objectType": "PERSON",
+          "userTypes": [
+            "GOOGLE_USER"
+          ]
+        }
+      }
+    ],
+    "objectType": "PERSON"
+  },
+  "names": [
+    {
+      "metadata": {
+        "primary": true,
+        "source": {
+          "type": "PROFILE",
+          "id": "115661085724677333632"
+        }
+      },
+      "displayName": "Oscar Carballo",
+      "familyName": "Carballo",
+      "givenName": "Oscar",
+      "displayNameLastFirst": "Carballo, Oscar"
+    }
+  ],
+  "photos": [
+    {
+      "metadata": {
+        "primary": true,
+        "source": {
+          "type": "PROFILE",
+          "id": "115661085724677333632"
+        }
+      },
+      "url": "https://lh6.googleusercontent.com/-1lUywZzxLoQ/AAAAAAAAAAI/AAAAAAAAAC0/c95Whdc5AAA/s100/photo.jpg"
+    }
+  ],
+  "genders": [
+    {
+      "metadata": {
+        "primary": true,
+        "source": {
+          "type": "PROFILE",
+          "id": "115661085724677333632"
+        }
+      },
+      "value": "male",
+      "formattedValue": "Male"
+    }
+  ],
+  "birthdays": [
+    {
+      "metadata": {
+        "primary": true,
+        "source": {
+          "type": "PROFILE",
+          "id": "115661085724677333632"
+        }
+      },
+      "date": {
+        "year": 1979,
+        "month": 10,
+        "day": 21
+      }
+    },
+    {
+      "metadata": {
+        "source": {
+          "type": "ACCOUNT",
+          "id": "115661085724677333632"
+        }
+      },
+      "date": {
+        "year": 1977,
+        "month": 12,
+        "day": 21
+      }
+    }
+  ],
+  "emailAddresses": [
+    {
+      "metadata": {
+        "primary": true,
+        "verified": true,
+        "source": {
+          "type": "ACCOUNT",
+          "id": "115661085724677333632"
+        }
+      },
+      "value": "oscar.carballo@scout24.com"
+    },
+    {
+      "metadata": {
+        "source": {
+          "type": "PROFILE",
+          "id": "115661085724677333632"
+        }
+      },
+      "value": "personal.email@google.com",
+      "type": "home",
+      "formattedType": "Home"
+    }
+  ]
+}


### PR DESCRIPTION
Add support to google people API

Prior to this, spring social google is only able to retrieve data
for google users who have a google plus account. Support to invoke google
people api ( https://developers.google.com/people/ ) is added, so now it
will be possible to access data from any google account.