### PR TITLE
Publish GoogleAutoConfiguration as auto-configuration class

### DIFF
--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+# Auto Configure
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.springframework.social.google.config.boot.GoogleAutoConfiguration


### PR DESCRIPTION
I noticed that the `GoogleAutoConfiguration` is not automatically discovered. However auto configuration works when using `@Import(GoogleAutoConfiguration.class)`. As far as I can tell this is because the `org.springframework.boot.autoconfigure.EnableAutoConfiguration` property is not defined in the project. Originally it was defined in 7bd39f378201df2a47fbe0c7c90361e03c24f779 in the spring-social-google/src/main/java/META-INF/MANIFEST.MF, but this file seems to have been deleted.

This PR attempts to bring back this config item.