### PR TITLE
Fix null account email

### DIFF
--- a/src/main/java/org/springframework/social/google/api/plus/Person.java
+++ b/src/main/java/org/springframework/social/google/api/plus/Person.java
@@ -197,7 +197,7 @@ public class Person extends ApiEntity {
   public String getAccountEmail() {
     if (emails != null) {
       for (final Entry<String, String> entry : emails.entrySet()) {
-        if (entry.getValue().equals("account")) {
+        if (entry.getValue().equalsIgnoreCase("account")) {
           return entry.getKey();
         }
       }


### PR DESCRIPTION
It seems google changed the email type from "account" to "ACCOUNT" in the user profile.
Fixes https://github.com/spring-social/spring-social-google/issues/118